### PR TITLE
Development organization

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  2.
+  3.
+
+## Specifications
+
+  - Northstar version:
+  - Platform:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,20 +2,6 @@
 
 Thank you for investing your time in contributing to our project!
 
-## Repositories architecture
-
-Northstar software is split into several repositories:
-
-* [Northstar](https://github.com/R2Northstar/Northstar) is the main repository; it only contains downloadable 
-versions of the client and wiki documentation (it does not contain source code).
-* [NorthstarMasterServer](https://github.com/R2Northstar/NorthstarMasterServer)
-holds source code of the master server, which is responsible for authentication, persistence, custom servers
-listing.
-* [NorthstarLauncher](https://github.com/R2Northstar/NorthstarLauncher) holds source code responsible for 
-injecting custom content (mods) into original game files.
-* [NorthstarMods](https://github.com/R2Northstar/NorthstarMods) contains mods recreating server gamelogic,
-enabling custom server hosting.
-
 ## Issues
 
 ### Create a new issue 
@@ -25,6 +11,5 @@ already exists on GitHub.
 
 Afterwards, please check Discord `faq`, `help` and `bug` channels for corresponding threads.
 
-Also, please double-check that you're opening an issue in the correct repository (read carefully `Repositories architecture`
-of this document if you're not sure).
+Also, please double-check that you're opening an issue in the correct repository (read carefully readme `Development` section if you're not sure).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ enabling custom server hosting.
 ### Create a new issue 
 
 If you find a bug while using Northstar, before posting it, please ensure that a corresponding issue does not 
-already exists.
+already exists on GitHub.
+
+Afterwards, please check Discord `faq`, `help` and `bug` channels for corresponding threads.
 
 Also, please double-check that you're opening an issue in the correct repository (read carefully `Repositories architecture`
 of this document if you're not sure).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for investing your time in contributing to our project!
 
 ## Repositories architecture
 
-Northstar software is splitted into several repositories:
+Northstar software is split into several repositories:
 
 * [Northstar](https://github.com/R2Northstar/Northstar) is the main repository; it only contains downloadable 
 versions of the client and wiki documentation (it does not contain source code).
@@ -14,7 +14,7 @@ listing.
 * [NorthstarLauncher](https://github.com/R2Northstar/NorthstarLauncher) holds source code responsible for 
 injecting custom content (mods) into original game files.
 * [NorthstarMods](https://github.com/R2Northstar/NorthstarMods) contains mods recreating server gamelogic,
-enabling custom serveurs hosting.
+enabling custom server hosting.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Welcome to Northstar contribution guide
+
+Thank you for investing your time in contributing to our project!
+
+## Repositories architecture
+
+Northstar software is splitted into several repositories:
+
+* [Northstar](https://github.com/R2Northstar/Northstar) is the main repository; it only contains downloadable 
+versions of the client and wiki documentation (it does not contain source code).
+* [NorthstarMasterServer](https://github.com/R2Northstar/NorthstarMasterServer)
+holds source code of the master server, which is responsible for authentication, persistence, custom servers
+listing.
+* [NorthstarLauncher](https://github.com/R2Northstar/NorthstarLauncher) holds source code responsible for 
+injecting custom content (mods) into original game files.
+* [NorthstarMods](https://github.com/R2Northstar/NorthstarMods) contains mods recreating server gamelogic,
+enabling custom serveurs hosting.
+
+## Issues
+
+### Create a new issue 
+
+If you find a bug while using Northstar, before posting it, please ensure that a corresponding issue does not 
+already exists.
+
+Also, please double-check that you're opening an issue in the correct repository (read carefully `Repositories architecture`
+of this document if you're not sure).
+


### PR DESCRIPTION
Currently, all issues are being opened on main repo, which does not grant a great visibility; ideally, there would be no `bugs` channel on Discord server, and all issues would be created in concerned repos.
Please don't hesitate to comment and add your ideas on this PR.

Adding some contributing documentation.
Adressing https://github.com/R2Northstar/Northstar/issues/55.

---

### Labels

#### Global

* feature
* bug
* suggestion
* priority-1
* priority-2
* priority-3
* priority-4
* priority-5
* server
* client

#### Specific

##### Northstar

##### Launcher

* updater

##### Mods

* UI

##### Master server

* authentication

###### TODOs

- [ ] Issues
    - [ ] Add issue template to all repositories (maybe we could create issues through integrated form: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms)
- [ ] Labels
    - [ ] List needed labels for each repo
    - [ ] Add labels to each repo