### PR TITLE
Delete startup args txt files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,6 @@ jobs:
       - name: Make package structure
         run: |
           mkdir -p thunderstore/dist/Northstar
-          rm northstar/ns_startup*.txt
           mv -v northstar/* thunderstore/dist/Northstar
           wget -O thunderstore/icon.png https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/icon.png
           wget -O thunderstore/README.md https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/README.md

--- a/release/ns_startup_args.txt
+++ b/release/ns_startup_args.txt
@@ -1,1 +1,0 @@
--multiple

--- a/release/ns_startup_args_dedi.txt
+++ b/release/ns_startup_args_dedi.txt
@@ -1,1 +1,0 @@
-+setplaylist private_match


### PR DESCRIPTION
Deletes `ns_startup_args.txt` and `ns_startup_args_dedi.txt`.
As per https://github.com/R2Northstar/NorthstarLauncher/pull/99 we no longer need them. NorthstarLauncher should just auto-create them when missing.