### PR TITLE
Strip `-rcX` suffix from version number properly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: northstar-launcher
         run: |
           sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' LauncherInjector/resources.rc
-          FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | tr -d '[:alpha:]')
+          FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
           sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDedicatedTest/ns_version.h
       - name: Build
         working-directory: northstar-launcher


### PR DESCRIPTION
Previously the digit of the rc as well as the dash would remain
E.g.: `-rc2` -> `-2`

This resulted in it being subtracted from the patch version digit
E.g.: `v1.7.0-rc1` turns into `1,7,0-1`.

This PR strips the whole `-rcX` part of the version number in CI

Closes #265