### PR TITLE
Enforce tags start with `v` for CI to run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
   workflow_dispatch:
     inputs:
       job:


### PR DESCRIPTION
Basically just a small safeguard to prevent running CI on accidentally pushed invalid tag.