### PR TITLE
Use tagged version of DiscordRPC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: R2Northstar/NorthstarDiscordRPC
+          ref: 'v1'
           path: discord-plugin
       - name: Checkout launcher repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This way builds are more reproducible as specific versions of NorthstarDiscordRPC can be set, meaning updating NorthstarDiscordRPC to newer plugin API won't immediately break CI runs of older Northstar release builds.

Closes #352 