### PR TITLE
Add step to create release draft and upload zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
           mv Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip ../
       - name: Upload zip to release draft
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-rc')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(env.NORTHSTAR_VERSION, '-rc')
         with:
           draft: true
           files: Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
           mv Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip ../
       - name: Upload zip to release draft
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/') && !contains(env.NORTHSTAR_VERSION, '-rc')
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(env.NORTHSTAR_VERSION, '-rc')
         with:
           draft: true
           files: Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           path: northstar
       - name: Upload zip to release draft
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-rc')
         with:
           draft: true
           files: northstar/Northstar.release.${{ env.NORTHSTAR_VERSION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
         required: true
         default: 'build-thunderstore-package'
 
+permissions:
+  contents: write # Needed to write to GitHub draft release
+
 env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}
 
@@ -130,12 +133,17 @@ jobs:
         with:
           name: Northstar.release.${{ env.NORTHSTAR_VERSION }}
           path: northstar
+      - name: Create zip to upload
+        run: |
+          cd northstar/
+          zip --recurse-paths --quiet Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip .
+          mv Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip ../
       - name: Upload zip to release draft
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-rc')
         with:
           draft: true
-          files: northstar/Northstar.release.${{ env.NORTHSTAR_VERSION }}
+          files: Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip
 
   build-thunderstore-package:
     needs: build-northstar # comment out when running locally

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,12 @@ jobs:
         with:
           name: Northstar.release.${{ env.NORTHSTAR_VERSION }}
           path: northstar
+      - name: Upload zip to release draft
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          files: northstar/Northstar.release.${{ env.NORTHSTAR_VERSION }}
 
   build-thunderstore-package:
     needs: build-northstar # comment out when running locally


### PR DESCRIPTION
Uses https://github.com/softprops/action-gh-release to create a draft release and upload the Northstar release zip to it.

I adapted the example [found here](https://github.com/softprops/action-gh-release#%EF%B8%8F-uploading-release-assets) for Northstar.

Not tested cause not sure how I'd do it with [act](https://github.com/nektos/act) without modifying releases on this repo...

