### PR TITLE
Grab pre-compiled DiscordRPC plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,6 @@ jobs:
   build-launcher:
     runs-on: windows-2022
     steps:
-      - name: Setup bundled plugins
-        uses: actions/checkout@v3
-        with:
-          repository: R2Northstar/NorthstarDiscordRPC
-          ref: 'v1'
-          path: discord-plugin
       - name: Checkout launcher repository
         uses: actions/checkout@v3
         with:
@@ -41,12 +35,10 @@ jobs:
           sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarLauncher/resources.rc
           FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
           sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDLL/ns_version.h
-      - name: Build
+      - name: Build Launcher
         working-directory: northstar-launcher
         run: |
-          cp -r ../discord-plugin/*Discord* .
           msbuild /p:Configuration=Release R2Northstar.sln
-          msbuild /p:Configuration=Release NorthstarDiscordRPC.sln
       - name: Upload launcher build as artifact
         uses: actions/upload-artifact@v3
         with:
@@ -55,8 +47,6 @@ jobs:
             northstar-launcher/x64/Release/Northstar.dll
             northstar-launcher/x64/Release/wsock32.dll
             northstar-launcher/x64/Release/NorthstarLauncher.exe
-            northstar-launcher/x64/Release/discord_game_sdk.dll
-            northstar-launcher/x64/Release/DiscordRPC.dll
             northstar-launcher/x64/Release/*.txt
       - name: Upload debug build artifact
         uses: actions/upload-artifact@v3
@@ -74,6 +64,9 @@ jobs:
         with:
           name: northstar-launcher
           path: northstar-launcher
+      - name: Download DiscordRPC plugin
+        run:
+          wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v2/northstar-discord-rpc.zip"
       - name: Download compiled stubs
         run:
           wget "https://github.com/R2Northstar/NorthstarStubs/releases/download/v1/NorthstarStubs.zip"
@@ -106,8 +99,10 @@ jobs:
           mkdir -p northstar/R2Northstar/plugins
           mkdir -p northstar/bin/x64_retail
 
-          mv -v northstar-launcher/DiscordRPC.dll northstar/R2Northstar/plugins
-          mv -v northstar-launcher/discord_game_sdk.dll northstar
+          unzip northstar-discord-rpc.zip
+          mv -v DiscordRPC.dll northstar/R2Northstar/plugins
+          mv -v discord_game_sdk.dll northstar
+
           mv -v northstar-launcher/wsock32.dll northstar/bin/x64_retail
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
 


### PR DESCRIPTION
Instead of re-compiling on each release, simply grab the precompiled DiscordRPC DLLs.

Shaves off around 1 minute of build time.

Sample run: https://github.com/GeckoEidechse/Temp-Northstar/actions/runs/4407266520
(Upload to Thunderstore is expected to fail on fork due to missing access key)