### PR TITLE
Bump download-artifact action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download compiled launcher
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: northstar-launcher
           path: northstar-launcher
@@ -171,7 +171,7 @@ jobs:
 
       - name: Download Northstar package
         if: ${{ !env.ACT }} # Download artifacts from previous jobs when running on GitHub's infrastructure
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: Northstar.release.${{ env.NORTHSTAR_VERSION }}
           path: northstar


### PR DESCRIPTION
To address a warning currently shown when running the checkout action:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/download-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
