### PR TITLE
Remove stray release dir from release zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Make folder structure
         run: |
           mv -v northstar/release/* northstar/.
+          rm -d release
           mkdir -p northstar/R2Northstar/mods
           mkdir -p northstar/R2Northstar/plugins
           mkdir -p northstar/bin/x64_retail


### PR DESCRIPTION
For some reason there's a stray empty `release` folder inside the release zip that shouldn't be there.