### PR TITLE
CONTRIBUTING.md facelift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for investing your time in contributing to our project!
 If you find a bug while using Northstar, before posting it, please ensure that a corresponding issue does not 
 already exists on GitHub.
 
-Afterwards, please check Discord `faq`, `help` and `bug` channels for corresponding threads.
+Afterwards, please check the [Northstar wiki's faq](https://r2northstar.gitbook.io/r2northstar-wiki/faq) and [troubleshooting page](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting) to see if there's already a solution to your issue.
 
 Also, please double-check that you're opening an issue in the correct repository (read carefully readme `Development` section if you're not sure).
 


### PR DESCRIPTION
Update to CONTRIBUTING.md

Probably isn't very heavily used but for one, the `bug` channel no longer exists in the discord and we are aiming to move towards using solely the wiki over solutions in discord channels. More of a nitpicky thing attempting to keep everything up to date than something that is necessary to change