### PR TITLE
Download launcher from release instead of rebuilding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
     steps:
       - name: Download compiled launcher
         run:
-          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/$NORTHSTAR_VERSION/northstar-launcher.zip"
+          export LAUNCHER_VERSION=$(echo $NORTHSTAR_VERSION | tr -d 'v')
+          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${LAUNCHER_VERSION}/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:
           wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
           mkdir -p northstar/bin/x64_dedi
 
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
-          #mv -v DiscordRPC.dll northstar/R2Northstar/plugins
           
           #unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download compiled launcher
-        uses: dsaltares/fetch-gh-release-asset@master
-        with:
-          repo: 'R2Northstar/NorthstarLauncher'
-          file: northstar-launcher.zip
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${{ env.NORTHSTAR_VERSION }}/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:
           wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
 on: [push]
-#  push:
-#    tags:
-#      - 'v*'
-#  workflow_dispatch:
-#    inputs:
-#      job:
-#        description: 'Job to run'
-#        required: true
-#        default: 'build-thunderstore-package'
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run'
+        required: true
+        default: 'build-thunderstore-package'
 
 permissions:
   contents: write # Needed to write to GitHub draft release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,8 @@ jobs:
           unzip northstar-discord-rpc.zip
           mv -v DiscordRPC.dll northstar/R2Northstar/plugins
           
-          unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
+          unzip NorthstarStubs.zip 
+          # -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Download compiled launcher
         run:
-          export LAUNCHER_VERSION=$(echo $NORTHSTAR_VERSION | tr -d 'v')
+          export LAUNCHER_VERSION=$(echo ${{ env.NORTHSTAR_VERSION }})
           wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${LAUNCHER_VERSION}/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
           git ls-tree -r $NORTHSTAR_VERSION --name-only | xargs -L1 md5sum >> md5sum.txt
       - name: Make folder structure
         run: |
+          mv -v northstar/release/* northstar/.
+          rm -d northstar/release
           mkdir -p northstar/R2Northstar/mods
           mkdir -p northstar/R2Northstar/plugins
           mkdir -p northstar/bin/x64_dedi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           
-          unzip -v northstar-launcher.zip northstar
+          unzip northstar-launcher.zip -d northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods
       - name: Checkout Navmesh repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: push
+on: [push]
 #  push:
 #    tags:
 #      - 'v*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
-on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      job:
-        description: 'Job to run'
-        required: true
-        default: 'build-thunderstore-package'
+on: [push]
+#  push:
+#    tags:
+#      - 'v*'
+#  workflow_dispatch:
+#    inputs:
+#      job:
+#        description: 'Job to run'
+#        required: true
+#        default: 'build-thunderstore-package'
 
 permissions:
   contents: write # Needed to write to GitHub draft release
@@ -17,53 +17,15 @@ env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}
 
 jobs:
-  build-launcher:
-    runs-on: windows-2022
-    steps:
-      - name: Checkout launcher repository
-        uses: actions/checkout@v3
-        with:
-          repository: R2Northstar/NorthstarLauncher
-          ref: ${{ env.NORTHSTAR_VERSION }}
-          path: northstar-launcher
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.1
-      - name: Setup resource file version
-        shell: bash
-        working-directory: northstar-launcher
-        run: |
-          sed -i 's/DEV/${{ env.NORTHSTAR_VERSION }}/g' NorthstarLauncher/resources.rc
-          FILEVERSION=$(echo ${{ env.NORTHSTAR_VERSION }} | tr '.' ',' | sed -E 's/-rc[0-9]+//' | tr -d '[:alpha:]')
-          sed -i "s/0,0,0,1/${FILEVERSION}/g" NorthstarDLL/ns_version.h
-      - name: Build Launcher
-        working-directory: northstar-launcher
-        run: |
-          msbuild /p:Configuration=Release R2Northstar.sln
-      - name: Upload launcher build as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: northstar-launcher
-          path: |
-            northstar-launcher/x64/Release/Northstar.dll
-            northstar-launcher/x64/Release/wsock32.dll
-            northstar-launcher/x64/Release/NorthstarLauncher.exe
-            northstar-launcher/x64/Release/*.txt
-      - name: Upload debug build artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: launcher-debug-files
-          path: |
-            northstar-launcher/x64/Release/*.pdb
-
   build-northstar:
-    needs: build-launcher
     runs-on: ubuntu-20.04
     steps:
       - name: Download compiled launcher
-        uses: actions/download-artifact@v3
+        uses: dsaltares/fetch-gh-release-asset@master
         with:
-          name: northstar-launcher
-          path: northstar-launcher
+          repo: 'R2Northstar/NorthstarLauncher'
+          file: northstar-launcher.zip
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download DiscordRPC plugin
         run:
           wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"
@@ -98,15 +60,14 @@ jobs:
           rm -d northstar/release
           mkdir -p northstar/R2Northstar/mods
           mkdir -p northstar/R2Northstar/plugins
-          mkdir -p northstar/bin/x64_retail
 
           unzip northstar-discord-rpc.zip
           mv -v DiscordRPC.dll northstar/R2Northstar/plugins
 
           mv -v northstar-launcher/wsock32.dll northstar/bin/x64_retail
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
-
-          mv -v northstar-launcher/* northstar
+          
+          unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods
       - name: Checkout Navmesh repository
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
           
-          #unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
+          unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,7 @@ jobs:
 
           unzip northstar-discord-rpc.zip
           mv -v DiscordRPC.dll northstar/R2Northstar/plugins
-
-          mv -v northstar-launcher/wsock32.dll northstar/bin/x64_retail
+          
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Download compiled launcher
         run:
-          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${{ env.NORTHSTAR_VERSION }}/northstar-launcher.zip"
+          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/$NORTHSTAR_VERSION/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:
           wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,16 +56,14 @@ jobs:
           git ls-tree -r $NORTHSTAR_VERSION --name-only | xargs -L1 md5sum >> md5sum.txt
       - name: Make folder structure
         run: |
-          mv -v northstar/release/* northstar/.
-          rm -d northstar/release
           mkdir -p northstar/R2Northstar/mods
           mkdir -p northstar/R2Northstar/plugins
+          mkdir -p northstar/bin/x64_dedi
 
-          unzip northstar-discord-rpc.zip
-          mv -v DiscordRPC.dll northstar/R2Northstar/plugins
+          unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
+          #mv -v DiscordRPC.dll northstar/R2Northstar/plugins
           
-          unzip NorthstarStubs.zip 
-          # -d northstar/bin/x64_dedi
+          unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,6 @@ jobs:
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
           
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
-          
           unzip northstar-launcher.zip -d northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods
       - name: Checkout Navmesh repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
-on: [push]
-#  push:
-#    tags:
-#      - 'v*'
-#  workflow_dispatch:
-#    inputs:
-#      job:
-#        description: 'Job to run'
-#        required: true
-#        default: 'build-thunderstore-package'
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'Job to run'
+        required: true
+        default: 'build-thunderstore-package'
 
 permissions:
   contents: write # Needed to write to GitHub draft release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,8 @@ jobs:
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
           #mv -v DiscordRPC.dll northstar/R2Northstar/plugins
           
-          unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
+          unzip NorthstarStubs.zip
+          # -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,14 @@
 name: Build
-on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      job:
-        description: 'Job to run'
-        required: true
-        default: 'build-thunderstore-package'
+on: push
+#  push:
+#    tags:
+#      - 'v*'
+#  workflow_dispatch:
+#    inputs:
+#      job:
+#        description: 'Job to run'
+#        required: true
+#        default: 'build-thunderstore-package'
 
 permissions:
   contents: write # Needed to write to GitHub draft release
@@ -22,8 +22,7 @@ jobs:
     steps:
       - name: Download compiled launcher
         run:
-          export LAUNCHER_VERSION=$(echo ${{ env.NORTHSTAR_VERSION }})
-          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${LAUNCHER_VERSION}/northstar-launcher.zip"
+          wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${{ env.NORTHSTAR_VERSION }}/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:
           wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,7 @@ jobs:
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
           #mv -v DiscordRPC.dll northstar/R2Northstar/plugins
           
-          unzip NorthstarStubs.zip
-          # -d northstar/bin/x64_dedi
+          #unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           
           unzip -v northstar-launcher.zip northstar
           rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
Fetches launcher build from latest release on NorthstarLauncher

NOTE: Due to the differences between old build system and cmake for the files to be structured properly a release on NorthstarLauncher needs to be made.

Closes #497