### PR TITLE
Bump NorthstarNavs to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: R2Northstar/NorthstarNavs
-          ref: 'v1'
+          ref: 'v2'
           path: northstar-navs
       - name: Navmeshes setup
         run: |


### PR DESCRIPTION
Bumps NorthstarNavs to newest release which includes https://github.com/R2Northstar/NorthstarNavs/pull/3