### PR TITLE
Use long form of args

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,14 +118,14 @@ jobs:
     steps:
       - name: Setup tcli
         run: |
-          wget -O tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.1.4/tcli-0.1.4-linux-x64.tar.gz
+          wget --output-document tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.1.4/tcli-0.1.4-linux-x64.tar.gz
           tar xvf tcli.tar.gz
           sudo mv --verbose tcli-0.1.4-linux-x64/tcli /bin
 
       - name: (DEBUG) Download Northstar package
         if: ${{ env.ACT }} # Download Northstar package from releases when running locally instead of relying on previous jobs
         run: |
-          wget -O northstar.zip https://github.com/R2Northstar/Northstar/releases/download/v1.6.3/Northstar.release.v1.6.3.zip
+          wget --output-document northstar.zip https://github.com/R2Northstar/Northstar/releases/download/v1.6.3/Northstar.release.v1.6.3.zip
           unzip northstar.zip -d northstar
 
       - name: Download Northstar package
@@ -139,8 +139,8 @@ jobs:
         run: |
           mkdir --parents thunderstore/dist/Northstar
           mv --verbose northstar/* thunderstore/dist/Northstar
-          wget -O thunderstore/icon.png https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/icon.png
-          wget -O thunderstore/README.md https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/README.md
+          wget --output-document thunderstore/icon.png https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/icon.png
+          wget --output-document thunderstore/README.md https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/README.md
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
         run: |
           mv -v northstar/release/* northstar/.
           rm -d northstar/release
-          mkdir -p northstar/R2Northstar/mods
-          mkdir -p northstar/R2Northstar/plugins
-          mkdir -p northstar/bin/x64_dedi
+          mkdir --parents northstar/R2Northstar/mods
+          mkdir --parents northstar/R2Northstar/plugins
+          mkdir --parents northstar/bin/x64_dedi
 
           unzip northstar-discord-rpc.zip -d northstar/R2Northstar/plugins
           
@@ -72,7 +72,7 @@ jobs:
           path: northstar-navs
       - name: Navmeshes setup
         run: |
-          mkdir -p northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
+          mkdir --parents northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
           mv -v northstar-navs/graphs northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
           mv -v northstar-navs/navmesh northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
       - name: Cleanup root Northstar repository files
@@ -137,7 +137,7 @@ jobs:
 
       - name: Make package structure
         run: |
-          mkdir -p thunderstore/dist/Northstar
+          mkdir --parents thunderstore/dist/Northstar
           mv -v northstar/* thunderstore/dist/Northstar
           wget -O thunderstore/icon.png https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/icon.png
           wget -O thunderstore/README.md https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/README.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           git ls-tree -r $NORTHSTAR_VERSION --name-only | xargs -L1 md5sum >> md5sum.txt
       - name: Make folder structure
         run: |
-          mv -v northstar/release/* northstar/.
+          mv --verbose northstar/release/* northstar/.
           rm --dir northstar/release
           mkdir --parents northstar/R2Northstar/mods
           mkdir --parents northstar/R2Northstar/plugins
@@ -73,8 +73,8 @@ jobs:
       - name: Navmeshes setup
         run: |
           mkdir --parents northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
-          mv -v northstar-navs/graphs northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
-          mv -v northstar-navs/navmesh northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
+          mv --verbose northstar-navs/graphs northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
+          mv --verbose northstar-navs/navmesh northstar/R2Northstar/mods/Northstar.CustomServers/mod/maps
       - name: Cleanup root Northstar repository files
         working-directory: northstar
         run: |
@@ -120,7 +120,7 @@ jobs:
         run: |
           wget -O tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.1.4/tcli-0.1.4-linux-x64.tar.gz
           tar xvf tcli.tar.gz
-          sudo mv -v tcli-0.1.4-linux-x64/tcli /bin
+          sudo mv --verbose tcli-0.1.4-linux-x64/tcli /bin
 
       - name: (DEBUG) Download Northstar package
         if: ${{ env.ACT }} # Download Northstar package from releases when running locally instead of relying on previous jobs
@@ -138,7 +138,7 @@ jobs:
       - name: Make package structure
         run: |
           mkdir --parents thunderstore/dist/Northstar
-          mv -v northstar/* thunderstore/dist/Northstar
+          mv --verbose northstar/* thunderstore/dist/Northstar
           wget -O thunderstore/icon.png https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/icon.png
           wget -O thunderstore/README.md https://raw.githubusercontent.com/R2Northstar/Northstar/main/thunderstore/README.md
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,9 +163,9 @@ jobs:
         run: |
           tcli init --package-name=$TS_MOD_NAME --package-namespace=$TS_NAMESPACE --package-version $MOD_VERSION
 
-          sed -i "s/communities = \[\]/communities = [\"$TS_COMMUNITY\"]/g" thunderstore.toml
-          sed -i "s/Example-Dependency = \"1.0.0\"//g" thunderstore.toml
-          sed -i "s/description = \"Example mod description\"/description = \"$TS_MOD_DESCRIPTION\"/g" thunderstore.toml
+          sed --in-place "s/communities = \[\]/communities = [\"$TS_COMMUNITY\"]/g" thunderstore.toml
+          sed --in-place "s/Example-Dependency = \"1.0.0\"//g" thunderstore.toml
+          sed --in-place "s/description = \"Example mod description\"/description = \"$TS_MOD_DESCRIPTION\"/g" thunderstore.toml
           cat thunderstore.toml
 
           tcli build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Make folder structure
         run: |
           mv -v northstar/release/* northstar/.
-          rm -d northstar/release
+          rm --dir northstar/release
           mkdir --parents northstar/R2Northstar/mods
           mkdir --parents northstar/R2Northstar/plugins
           mkdir --parents northstar/bin/x64_dedi


### PR DESCRIPTION
Use long form of commands (e.g. `mkdir --parents` instead of `mkdir -p`).
The reason for this being that short form commands are too ambiguous, for example `-v` can mean either `--verbose` or `--version` depending on the tool.
Further long-form versions are more self-explanatory, e.g. `sed -i` (what does it do ???) `sed --in-place` (ah, in-place replacement).