### PR TITLE
Publish Mastodon post on new release

### DIFF
--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -14,7 +14,7 @@ jobs:
           id: mastodon
           uses: cbrgm/mastodon-github-action@v1
           with:
-            message: "Hello from GitHub Actions!"
+            message: "We just released a new Northstar version: ${{github.event.release.tag_name}}"
           env:
             MASTODON_URL: ${{ secrets.MASTODON_URL }}
             MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -3,9 +3,6 @@ on:
   release:
     types: [published]
 
-env:
-  NORTHSTAR_VERSION: ${{ github.ref_name }}
-
 jobs:
   toot:
     runs-on: ubuntu-22.04

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -11,7 +11,7 @@ jobs:
         id: mastodon
         uses: cbrgm/mastodon-github-action@v1
         with:
-          message: "We just released a new Northstar version: ${{github.event.release.tag_name}}"
+          message: "We just released Northstar ${{ github.event.release.tag_name }}\n\n${{ github.event.release.html_url }}"
         env:
           MASTODON_URL: ${{ secrets.MASTODON_URL }}
           MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -7,7 +7,7 @@ env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}
 
 jobs:
-  build-northstar:
+  toot:
     runs-on: ubuntu-22.04
     steps:
         - name: Send toot to Mastodon

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,7 +1,7 @@
 name: Post-to-Mastodon
 on:
   release:
-    types: [ created ]
+    types: [ published ]
 
 env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,7 +1,7 @@
 name: Post-to-Mastodon
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,0 +1,18 @@
+name: Post-to-Mastodon
+on: [push]
+
+env:
+  NORTHSTAR_VERSION: ${{ github.ref_name }}
+
+jobs:
+  build-northstar:
+    runs-on: ubuntu-22.04
+    steps:
+        - name: Send toot to Mastodon
+          id: mastodon
+          uses: cbrgm/mastodon-github-action@v1
+          with:
+            message: "Hello from GitHub Actions!"
+          env:
+            MASTODON_URL: ${{ secrets.MASTODON_URL }}
+            MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,5 +1,7 @@
 name: Post-to-Mastodon
-on: [push]
+on:
+  release:
+    types: [ created ]
 
 env:
   NORTHSTAR_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -10,11 +10,11 @@ jobs:
   toot:
     runs-on: ubuntu-22.04
     steps:
-        - name: Send toot to Mastodon
-          id: mastodon
-          uses: cbrgm/mastodon-github-action@v1
-          with:
-            message: "We just released a new Northstar version: ${{github.event.release.tag_name}}"
-          env:
-            MASTODON_URL: ${{ secrets.MASTODON_URL }}
-            MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+      - name: Send toot to Mastodon
+        id: mastodon
+        uses: cbrgm/mastodon-github-action@v1
+        with:
+          message: "We just released a new Northstar version: ${{github.event.release.tag_name}}"
+        env:
+          MASTODON_URL: ${{ secrets.MASTODON_URL }}
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds an action that publishes a new Mastodon post linking to the newest release when it is released.
Posts are sent from https://fosstodon.org/@R2Northstar

Uses https://github.com/cbrgm/mastodon-github-action/