### PR TITLE
Bump DiscordRPC plugin to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           wget "https://github.com/R2Northstar/NorthstarLauncher/releases/download/${{ env.NORTHSTAR_VERSION }}/northstar-launcher.zip"
       - name: Download DiscordRPC plugin
         run:
-          wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v4/northstar-discord-rpc.zip"
+          wget "https://github.com/R2Northstar/NorthstarDiscordRPC/releases/download/v5/northstar-discord-rpc.zip"
       - name: Download compiled stubs
         run:
           wget "https://github.com/R2Northstar/NorthstarStubs/releases/download/v1/NorthstarStubs.zip"


### PR DESCRIPTION
Bump DiscordRPC plugin to v5 which corresponds to the first version that supports plugins v3.


See also:

- https://github.com/R2Northstar/NorthstarDiscordRPC/pull/10
- https://github.com/R2Northstar/NorthstarMods/pull/652
- https://github.com/R2Northstar/NorthstarLauncher/pull/472