### PR TITLE
Escape backticks in run command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,9 @@ jobs:
       - name: Compute SHA-512 checksum
         run: |
           sha512sum Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           sha512sum Northstar.release.${{ env.NORTHSTAR_VERSION }}.zip >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
       - name: Upload zip to release draft
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v') && !contains(env.NORTHSTAR_VERSION, '-rc')


### PR DESCRIPTION
Escape backticks in run command as otherwise bash thinks we're trying to run the command "`"