### PR TITLE
Bump CI runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   build-northstar:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout release files
         uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
       TS_NAMESPACE: northstar
       TS_MOD_NAME: Northstar
       TS_MOD_DESCRIPTION: Titanfall 2 modding and custom server framework.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup tcli
         run: |


### PR DESCRIPTION
Bump runner to from Ubuntu 20.04 to 22.04.

Bumps it to the currently latest LTS Ubuntu runner. I'm still manually specifying runner version over `latest` to avoid any potential breakage on new release.
