### PR TITLE
chore: Bump tcli to 0.2.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,9 @@ jobs:
     steps:
       - name: Setup tcli
         run: |
-          wget --output-document tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.2.3/tcli-0.2.3-linux-x64.tar.gz
+          wget --output-document tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.2.4/tcli-0.2.4-linux-x64.tar.gz
           tar xvf tcli.tar.gz
-          sudo mv --verbose tcli-0.2.3-linux-x64/tcli /bin
+          sudo mv --verbose tcli-0.2.4-linux-x64/tcli /bin
 
       - name: (DEBUG) Download Northstar package
         if: ${{ env.ACT }} # Download Northstar package from releases when running locally instead of relying on previous jobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,9 +125,9 @@ jobs:
     steps:
       - name: Setup tcli
         run: |
-          wget --output-document tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.1.4/tcli-0.1.4-linux-x64.tar.gz
+          wget --output-document tcli.tar.gz https://github.com/thunderstore-io/thunderstore-cli/releases/download/0.2.3/tcli-0.2.3-linux-x64.tar.gz
           tar xvf tcli.tar.gz
-          sudo mv --verbose tcli-0.1.4-linux-x64/tcli /bin
+          sudo mv --verbose tcli-0.2.3-linux-x64/tcli /bin
 
       - name: (DEBUG) Download Northstar package
         if: ${{ env.ACT }} # Download Northstar package from releases when running locally instead of relying on previous jobs


### PR DESCRIPTION
We are still on `0.1.4` which is over two years old now.

And we keep getting `Gateway Timeout` errors recently  now