### PR TITLE
Bump upload/download artifact actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           rm -rf .git .github .gitignore *.md LICENSE thunderstore .ci.env.example *.sh
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Northstar.release.${{ env.NORTHSTAR_VERSION }}
           path: northstar
@@ -137,7 +137,7 @@ jobs:
 
       - name: Download Northstar package
         if: ${{ !env.ACT }} # Download artifacts from previous jobs when running on GitHub's infrastructure
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Northstar.release.${{ env.NORTHSTAR_VERSION }}
           path: northstar


### PR DESCRIPTION
Bump upload/download artifact actions to v4 as v3 is being deprecated in a few months

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/