### PR TITLE
Exclude markdown files from Mods in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
           unzip NorthstarStubs.zip -d northstar/bin/x64_dedi
           unzip northstar-launcher.zip -d northstar
-          rsync -avr --exclude="Northstar.Coop" --exclude=".git*" northstar-mods/. northstar/R2Northstar/mods
+          rsync -avr --exclude="Northstar.Coop" --exclude=".git*" --exclude="*.md" northstar-mods/. northstar/R2Northstar/mods
       - name: Checkout Navmesh repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We currently add the `README.md` for NorthstarMods into release zip but there's no reason for it to be there.