### PR TITLE
Update links to point to new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/R2Northstar/Northstar)](https://github.com/R2Northstar/Northstar/releases)
 ![GitHub release downloads (latest by date)](https://img.shields.io/github/downloads/R2Northstar/Northstar/latest/total)
 [![Join the chat at Discord](https://img.shields.io/badge/chat-on%20discord-7289DA.svg)](https://northstar.tf/discord)
-[![Read the wiki](https://img.shields.io/badge/wiki-GitBook-important)](https://r2northstar.gitbook.io)
+[![Read the wiki](https://img.shields.io/badge/wiki-MKDocs-important)](https://northstar.tf/wiki)
 
 Northstar is a modding framework client that allows users to host their own Titanfall 2 servers using custom scripts and assets to create custom content, as well as being able to host vanilla content.
 
 <p align="center"><strong>
-<a href="https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/basic-setup">Installation</a> | <a href="https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting">Troubleshooting</a> | <a href="https://r2northstar.gitbook.io/">Wiki</a>
+<a href="https://docs.northstar.tf/Wiki/installing-northstar/basic-setup/">Installation</a> | <a href="https://docs.northstar.tf/Wiki/installing-northstar/troubleshooting/">Troubleshooting</a> | <a href="https://northstar.tf/wiki">Wiki</a>
 </strong></p>
 
 ## Development
@@ -22,10 +22,9 @@ Northstar's development is split into 6 repositories:
 1. [NorthstarDiscordRPC](https://github.com/R2Northstar/NorthstarDiscordRPC) (Discord RPC plugin)
 1. [Atlas](https://github.com/R2Northstar/Atlas) (Backend API for server browser, player authentication, and persistence)
 
-The documentation is split into three repositories:
+The documentation is split into two repositories:
 1. [NorthstarTF](https://github.com/R2Northstar/NorthstarTF) (Main website)
-1. [NorthstarWiki](https://github.com/R2Northstar/NorthstarWiki) (Wiki covering installation, hosting and configuration of Northstar)
-1. [ModdingDocs](https://github.com/R2Northstar/ModdingDocs) (Guides and tutorials on how to mod using Northstar)
+1. [ModdingDocs](https://github.com/R2Northstar/ModdingDocs) (Wiki covering installation, hosting and configuration of Northstar, as well as guides and tutorials on how to mod using Northstar)
 
 ## Special Thanks
 


### PR DESCRIPTION
Updates the wiki links to point to the new wiki. Also removes mention of the deprecated `NorthstarWiki` repo